### PR TITLE
Fix Wine 10 and fakeroot install issues

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = bakkesmod-steam
 	pkgdesc = A mod aimed at making you better at Rocket League!
 	pkgver = 2.69
-	pkgrel = 2
+	pkgrel = 3
 	url = https://bakkesmod.com/
 	arch = x86_64
 	license = GPL
 	makedepends = python
 	source = dll-2-0-69-2.zip::https://github.com/bakkesmodorg/BakkesModInjectorCpp/releases/download/2.0.69.2/bakkesmod.zip
 	source = src-2-0-69-2.zip::https://github.com/bakkesmodorg/BakkesModInjectorCpp/archive/refs/tags/2.0.69.2.zip
-	source = loopback-2-69-2.zip::https://github.com/kentslaney/bakkesmod-arch/archive/refs/tags/2.69-2-steam.zip
+	source = loopback-2-69-3.zip::https://github.com/kentslaney/bakkesmod-arch/archive/refs/tags/2.69-3-steam.zip
 	source = https://github.com/kentslaney/bakkesmod-arch/releases/download/c369f24-1/inject.exe
 	source = https://github.com/kentslaney/bakkesmod-arch/releases/download/05ea332-1/powershell32.exe
 	source = https://github.com/kentslaney/bakkesmod-arch/releases/download/05ea332-1/powershell64.exe

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -109,6 +109,13 @@ proton_paths=$(cat <<'EOF'
         exit 1
     fi
     proton=`sed -n 3p "$compat/config_info" | xargs -d '\n' dirname`
+    # Wine 10+ unified wine64 into wine; fall back when no legacy symlink exists
+    wine_bin="$proton/bin/wine64"
+    if [ ! -x "$wine_bin" ]; then wine_bin="$proton/bin/wine"; fi
+    if [ ! -x "$wine_bin" ]; then
+        echo "could not find proton wine executable" >&2
+        exit 1
+    fi
     bm_pfx="$compat/pfx/drive_c/users/steamuser/AppData/Roaming/bakkesmod"
 EOF
 )
@@ -127,8 +134,9 @@ build_version() {
 }
 
 powershell_installer() {
-    "$1" 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe' -noni -c 'echo "powershell64_installed"'
-    "$1" 'C:\windows\syswow64\WindowsPowerShell\v1.0\powershell.exe' -noni -c 'echo "powershell32_installed"'
+    # under fakeroot, wineserver sees the spoofed UID via LD_PRELOAD but wine-preloader bypasses it; clear LD_PRELOAD so both see the real UID
+    env -u LD_PRELOAD "$1" 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe' -noni -c 'echo "powershell64_installed"'
+    env -u LD_PRELOAD "$1" 'C:\windows\syswow64\WindowsPowerShell\v1.0\powershell.exe' -noni -c 'echo "powershell32_installed"'
 }
 
 powershell() {
@@ -159,7 +167,7 @@ package() {
     cat <<"    EOF" >> "$srcdir/runner.sh"
         dll=`[ "$PROMPTLESS" = 1 ] && echo "bakkesmod_promptless.dll" || echo "bakkesmod_official.dll"`
         ln -sf "$bm_pfx/bakkesmod/dll/$dll" "$bm_pfx/bakkesmod/dll/bakkesmod.dll"
-        WINEFSYNC=1 WINEPREFIX="$compat/pfx/" "$proton/bin/wine64" "$@"
+        env -u LD_PRELOAD WINEFSYNC=1 WINEPREFIX="$compat/pfx/" "$wine_bin" "$@"
     EOF
     chmod a+x "$srcdir/runner.sh"
     mkdir -p "$bm_pfx"
@@ -217,7 +225,7 @@ package() {
     if [ -f "$compat/pfx/drive_c/Program Files/PowerShell/7/pwsh.exe" ]; then
         echo "skipping powershell installation in favor of existing pwsh.exe"
     else
-        ( cd "$srcdir" && WINEPREFIX="$compat/pfx/" powershell "$proton/bin/wine64" )
+        ( cd "$srcdir" && WINEPREFIX="$compat/pfx/" powershell "$wine_bin" )
     fi
     echo "to finish installing, update your launch options by prepending \"BAKKES=1\" or by setting them to \"BAKKES=1 %command%\" if none have been set yet"
     echo "to inject the bakkesmod DLL without the message box about version verification, also prepend \"PROMPTLESS=1\""

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=bakkesmod-steam
 rlver=( 2 0 69 2 )
 pkgver="${rlver[0]}.${rlver[2]}"
-pkgrel=2
+pkgrel=3
 pkgdesc="A mod aimed at making you better at Rocket League!"
 arch=('x86_64')
 url="https://bakkesmod.com/"


### PR DESCRIPTION
## Summary
- fall back to `proton/bin/wine` when `wine64` is not present for Wine 10+ Proton builds
- clear `LD_PRELOAD` around Wine/PowerShell invocations so fakeroot does not confuse wineserver vs wine-preloader UID handling
- use the detected Wine executable in the generated runner and PowerShell install path

## Bug Reference
- Fixes https://github.com/kentslaney/bakkesmod-arch/issues/21
- Related upstream packaging context: https://gitlab.archlinux.org/archlinux/packaging/packages/wine/-/issues/17

## Checks
- `bash -n PKGBUILD`
- `git diff --check`
